### PR TITLE
fix null handover

### DIFF
--- a/src/Token/HttpAuthentification.php
+++ b/src/Token/HttpAuthentification.php
@@ -16,6 +16,10 @@ class HttpAuthentification extends AbstractToken
     {
         $value = $this->getArrayValue($_SERVER, 'HTTP_AUTHENTICATION');
 
+        if (is_null($value)){
+          throw new AuthentificationException('Failed to parse token.');
+        }
+
         if (strtolower(substr($value, 0, 5)) !== 'basic') {
             throw new AuthentificationException('Failed to parse token.');
         }

--- a/src/Token/HttpAuthorization.php
+++ b/src/Token/HttpAuthorization.php
@@ -16,6 +16,10 @@ class HttpAuthorization extends AbstractToken
     {
         $value = $this->getArrayValue($_SERVER, 'HTTP_AUTHORIZATION');
 
+        if (is_null($value)){
+          throw new AuthentificationException('Failed to parse token.');
+        }
+
         if (strtolower(substr($value, 0, 6)) !== 'digest') {
             throw new AuthentificationException('Failed to parse token.');
         }


### PR DESCRIPTION
PHP 8.2 complains about handing over null value instead of string